### PR TITLE
S3 bucket versioning req update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 description = "Mongoose is a high-load storage performance testing tool"
 group = "com.github.emc-mongoose"
-version = "4.2.14"
+version = "4.2.15"
 sourceCompatibility = 11
 targetCompatibility = 11
 

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -54,8 +54,8 @@ build:
   stage: build
   script:
     - ./gradlew clean jar
-  #tags:
-  #  - s3
+  tags:
+    - s3
   artifacts:
     paths:
       - build/libs/mongoose-*.jar
@@ -64,16 +64,16 @@ test_unit:
   stage: test
   script:
     - ./gradlew test
-  #tags:
-  #  - s3
+  tags:
+    - s3
 
 
 test_integration:
   stage: test
   script:
     - ./gradlew integrationTest
-  #tags:
-  #  - s3
+  tags:
+    - s3
   artifacts:
     paths:
       - build/reports/tests/integrationTest/*
@@ -85,8 +85,8 @@ build_docker_image:
     - ./gradlew dockerBuildImage
     - export VERSION=$(cat build.gradle | grep version\ = | sed -n 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
     - docker save ${IMAGE_NAME}:${VERSION} > ${IMAGE_FILE_NAME}
-  #tags:
-  #  - s3
+  tags:
+    - s3
   artifacts:
     paths:
       - ${IMAGE_FILE_NAME}
@@ -111,8 +111,8 @@ build_docker_image:
     - robot --outputdir build/robotest --suite ${SUITE} --include ${TEST} src/test/robot
   after_script:
     - rebot build/robotest/output.xml
-  #tags:
-  #  - s3
+  tags:
+    - s3
   artifacts:
     paths:
       - build/robotest/*.html
@@ -132,6 +132,8 @@ release_to_maven_repo:
     - mkdir /tmp/.gnupg
     - if [ ! -z "$GPG_SECRING" ]; then echo $GPG_SECRING | base64 -d > /tmp/.gnupg/secring.gpg; fi
     - ./gradlew -Psigning.keyId=${SIGNING_KEY_ID} -Psigning.password=${SIGNING_PASSWORD} -Psigning.secretKeyRingFile=/tmp/.gnupg/secring.gpg -PossrhUsername=${OSSRH_USERNAME} -PossrhPassword=${OSSRH_PASSWORD} publishToNexus closeAndReleaseRepository
+  tags:
+    - s3
   only:
     - latest
   except:
@@ -146,6 +148,8 @@ release_to_docker_hub:
     - docker push ${IMAGE_NAME}:${VERSION}
     - docker tag ${IMAGE_NAME}:${VERSION} ${IMAGE_NAME}:latest
     - docker push ${IMAGE_NAME}:latest
+  tags:
+    - s3
   only:
     - latest
   except:


### PR DESCRIPTION
We do bucket versioning request even if user didn't ask for versioning at all, wasting ports in case there are hundreds of buckets and objects. Easy way to run out of ports: item-output-path='data/${rnd.nextInt(256)}/${rnd.nextInt(256)}'